### PR TITLE
Rsync exclude

### DIFF
--- a/barman/backup_executor.py
+++ b/barman/backup_executor.py
@@ -953,7 +953,8 @@ class RsyncBackupExecutor(SshBackupExecutor):
             label='pgdata',
             src=':%s/' % backup_info.pgdata,
             dst=backup_dest,
-            exclude=self.PGDATA_EXCLUDE_LIST + self.EXCLUDE_LIST,
+            exclude=self.PGDATA_EXCLUDE_LIST + self.EXCLUDE_LIST +
+                self.config.rsync_exclude,
             exclude_and_protect=exclude_and_protect,
             bwlimit=self.config.get_bwlimit(),
             reuse=self._reuse_path(previous_backup),

--- a/barman/config.py
+++ b/barman/config.py
@@ -260,6 +260,18 @@ def parse_backup_method(value):
             "', '".join(BACKUP_METHOD_VALUES)))
 
 
+def parse_rsync_exclude(value):
+    """
+    Parse a list of filesystem objects (which are free-form, 
+    and may or may not exist) which will be excluded from rsync backup
+    """
+    if value:
+        values_list = value.split(',')
+    else:
+        values_list = ['']
+    return values_list
+
+
 class ServerConfig(object):
     """
     This class represents the configuration for a specific Server instance.
@@ -383,6 +395,7 @@ class ServerConfig(object):
         'network_compression': 'false',
         'recovery_options': '',
         'retention_policy_mode': 'auto',
+        'rsync_exclude': '',
         'streaming_archiver': 'off',
         'streaming_archiver_batch_size': '0',
         'streaming_archiver_name': 'barman_receive_wal',
@@ -412,7 +425,7 @@ class ServerConfig(object):
         'network_compression': parse_boolean,
         'recovery_options': RecoveryOptions,
         'reuse_backup': parse_reuse_backup,
-        'rsync_exclude': CsvOption,
+        'rsync_exclude': parse_rsync_exclude,
         'streaming_archiver': parse_boolean,
         'streaming_archiver_batch_size': int,
     }

--- a/barman/config.py
+++ b/barman/config.py
@@ -306,6 +306,7 @@ class ServerConfig(object):
         'retention_policy',
         'retention_policy_mode',
         'reuse_backup',
+        'rsync_exclude',
         'slot_name',
         'ssh_command',
         'streaming_archiver',
@@ -353,6 +354,7 @@ class ServerConfig(object):
         'retention_policy',
         'retention_policy_mode',
         'reuse_backup',
+        'rsync_exclude',
         'slot_name',
         'streaming_archiver',
         'streaming_archiver_batch_size',
@@ -410,6 +412,7 @@ class ServerConfig(object):
         'network_compression': parse_boolean,
         'recovery_options': RecoveryOptions,
         'reuse_backup': parse_reuse_backup,
+        'rsync_exclude': CsvOption,
         'streaming_archiver': parse_boolean,
         'streaming_archiver_batch_size': int,
     }

--- a/tests/testing_helpers.py
+++ b/tests/testing_helpers.py
@@ -276,6 +276,7 @@ def build_config_dictionary(config_keys=None):
         'streaming_archiver': False,
         'streaming_wals_directory': '/some/barman/home/main/streaming',
         'errors_directory': '/some/barman/home/main/errors',
+        'rsync_exclude': '/some/barman/excluded/dir',
     }
     # Check for overriding keys
     if config_keys is not None:


### PR DESCRIPTION
These changes allow a user to specify filesystem objects they don't want copied with rsync. We use it with the cstore_fdw foreign data wrapper to avoid needlessly copying ~22TB of static data every time we do a base backup.